### PR TITLE
Add SIG api-machinery to participating-sigs

### DIFF
--- a/keps/sig-instrumentation/1668-trace-popagating/kep.yaml
+++ b/keps/sig-instrumentation/1668-trace-popagating/kep.yaml
@@ -8,6 +8,7 @@ authors:
  - "@Hellcatlk"
 owning-sig: sig-instrumentation
 participating-sigs:
+  - sig-api-machinery
 status: provisional
 creation-date: 2020-09-01
 last-updated: 2021-01-21


### PR DESCRIPTION
Signed-off-by: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>

Add SIG api-machinery to participating-sigs as [this comment](https://github.com/kubernetes/enhancements/pull/2312#discussion_r565495149) suggested.